### PR TITLE
test: Fixed test to work with non default constructor.

### DIFF
--- a/CE3D/test/camera/orthographic_camera_test.cpp
+++ b/CE3D/test/camera/orthographic_camera_test.cpp
@@ -28,7 +28,8 @@ BOOST_AUTO_TEST_CASE(TestOrthographicCameraConstruction)
 {
     CE3D::OrthographicCamera<CE3D::ConsoleMaterial> *TestUnit;
     BOOST_REQUIRE_NO_THROW(
-        TestUnit = new CE3D::OrthographicCamera<CE3D::ConsoleMaterial>());
+        TestUnit = new CE3D::OrthographicCamera<CE3D::ConsoleMaterial>
+        (CE3D::Vector(), CE3D::Vector()));
     BOOST_REQUIRE_NO_THROW(delete TestUnit);
 }
 
@@ -37,8 +38,9 @@ BOOST_AUTO_TEST_CASE(TestOrthographicCameraConstruction)
  */
 BOOST_AUTO_TEST_CASE(TestPropertyFunctions)
 {
-    CE3D::OrthographicCamera<CE3D::ConsoleMaterial> cam;
-   
+    CE3D::OrthographicCamera<CE3D::ConsoleMaterial> cam
+        ((CE3D::Vector()), (CE3D::Vector()));
+
     CE3D::Vector testvector(5);
     testvector(0) = 17;
     testvector(1) = 1;
@@ -67,7 +69,8 @@ BOOST_AUTO_TEST_CASE(TestPropertyFunctions)
  */
 BOOST_AUTO_TEST_CASE(TestMatrix)
 {
-    CE3D::OrthographicCamera<CE3D::ConsoleMaterial> cam;
+    CE3D::OrthographicCamera<CE3D::ConsoleMaterial> cam
+        ((CE3D::Vector()), (CE3D::Vector()));
 
     std::shared_ptr<CE3D::World<CE3D::ConsoleMaterial>> 
         world(new CE3D::World<CE3D::ConsoleMaterial>());


### PR DESCRIPTION
And there's the reason why not to forbid the parameterless default constructor.
The user can easily instantiate the same with his own instantiation of CE3D::Vector.
Also I think when the user hasn't given a specific vector, the Paint() function shall fail when using non-initialized transformations inside the camera. This indicates the user to set some appropriate vectors.

So the question: Should I support again the parameterless default constructor?
